### PR TITLE
Fix: instant redirect instead of "See Other" page

### DIFF
--- a/gotiny/tiny.go
+++ b/gotiny/tiny.go
@@ -91,7 +91,6 @@ func handleRedirect(w http.ResponseWriter, r *http.Request) {
 		log.Print("No url found in store")
 	}
 	log.Printf("Redirecting to: %s", fullURL)
-	w.WriteHeader(303)
 	http.Redirect(w, r, fullURL, http.StatusSeeOther)
 }
 


### PR DESCRIPTION
Calling [`http.Redirect`](https://golang.org/pkg/net/http/#Redirect) writes the HTTP status code to the header automatically. Doing it manually beforehand causes the following warning:

```
2019/10/12 14:29:37 http: superfluous response.WriteHeader call from main.handleRedirect (tiny.go:67)
```